### PR TITLE
[fix] ssd reader 기능에 대한 testcase @skip 삭제

### DIFF
--- a/tests/test_ssd_reader.py
+++ b/tests/test_ssd_reader.py
@@ -21,7 +21,7 @@ class TestSSDReader(TestCase):
     def tearDown(self):
         os.remove(READ_FILE_DIR)
 
-    @skip
+
     def test_read(self):
         ssd_reader = SSDReader()
 


### PR DESCRIPTION
## 제목
ssd reader testcase에서 @skip 삭제

## 설명
ssd reader testcase에서 @skip 삭제했습니다.
( ssd reader 기능 업로드 시 누락 )

## 체크리스트
- [x] 코드가 컴파일 오류 없이 정상적으로 동작함
- [x] 모든 테스트가 성공적으로 통과함

## 변경 사항
- `test_ssd_reader.py` : testcase에서 @skip삭제 
